### PR TITLE
Make Documents Input use show_help option

### DIFF
--- a/perl_lib/EPrints/Plugin/InputForm/Component/Documents.pm
+++ b/perl_lib/EPrints/Plugin/InputForm/Component/Documents.pm
@@ -522,6 +522,7 @@ sub _render_doc_metadata
 								$doc_prefix ),
 			help=>$field->render_help($session),
 			help_prefix=>$doc_prefix."_".$field->get_name."_help",
+			no_toggle=>$self->{no_toggle}
 		));
 		$first = 0;
 	}


### PR DESCRIPTION
The "show_help" for the Documents component was being ignored if set in the workflow. This fix pulls the option through.